### PR TITLE
Feature: Define package `logger` as a wrapper over `uber-go/zap`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-## Description
-
 <!--
   Add a detailed description for the changes made in this pull request
 
@@ -22,7 +20,7 @@
 <!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
 - [ ] I've read the [`Code of Conduct`](../blob/master/CODE_OF_CONDUCT.md) and this pull request adheres to it.
 - [ ] I've read the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) guide.
-- [ ] I've ran the complete test-suite using `make test-suite`, and it passed with no errors.
+- [ ] I've run the complete test-suite using `make test-suite`, and it passed with no errors.
 - [ ] I've written new tests for all changes introduced in this pull request (where applicable).
 - [ ] I've documented any new methods/structures/packages added.
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,62 @@
 package main
 
 import (
-	"fmt"
+	"os"
+
+	"github.com/notsatan/crcgen/src/logger"
+)
+
+const (
+	pkgName   = "main"
+	debugMode = "debug_mode"
+)
+
+var (
+	// initLogger maps calls to logger.Log
+	initLogger = logger.Log
+
+	// exit maps calls to os.Exit
+	exit = os.Exit
+
+	// closeLogger maps calls to logger.Stop
+	closeLogger = logger.Stop
 )
 
 func main() {
-	fmt.Println("Running")
+	defer closeRes()
+
+	if _, ok := os.LookupEnv(debugMode); ok {
+		// In `debug` mode, switch logger to write all logs to `stderr`
+		err := initLogger(false)
+		crashOnErr(err, "Failed to start logger")
+
+		logger.Debugf("(%s/main): Detected `debug` mode", pkgName)
+	}
+}
+
+/*
+crashOnErr is a simple helper function to ensure a "graceful" crash if the main thread
+encounters an error.
+
+The function prints an error message to the user, closes resources and force closes the
+application
+*/
+func crashOnErr(err error, cause string) {
+	if err == nil {
+		return
+	}
+
+	logger.Errorf("(%s/main): %s: %s", pkgName, cause, err)
+	closeRes() // close resources
+
+	exit(-10)
+}
+
+/*
+closeRes attempts to close resources, designed to be run before the app closes
+*/
+func closeRes() {
+	if err := closeLogger(); err != nil {
+		logger.Errorf("(%s/main): Failed to close logger: %s", pkgName, err)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/notsatan/crcgen/src/logger"
 )
 
 const (
@@ -18,9 +24,19 @@ func resetEnv() {
 	_ = os.Unsetenv(envBuild)
 }
 
+func reset() {
+	exit = os.Exit
+	initLogger = logger.Log
+	closeLogger = logger.Stop
+}
+
 func TestMain(m *testing.M) {
 	// Run all tests, unset env variables, and exit
 	resetEnv()
+
+	// TODO: Figure out a better way than running tests in debug mode
+	_ = os.Setenv(debugMode, "debug")
+
 	val := m.Run()
 	resetEnv()
 	os.Exit(val)
@@ -28,4 +44,30 @@ func TestMain(m *testing.M) {
 
 func TestMainMethod(_ *testing.T) {
 	main()
+}
+
+func TestCrashOnErr(t *testing.T) {
+	defer reset()
+
+	calls := 0
+	exit = func(int) { calls++ } // increment `calls` when `exit` is run by `CrashOnErr`
+
+	crashOnErr(nil, "") // `exit` should not be called without an error
+	assert.Equal(t, calls, 0)
+
+	crashOnErr(errors.New("test"), "test message")
+	assert.Equal(t, calls, 1)
+}
+
+func TestCloseRes(t *testing.T) {
+	defer reset()
+
+	// `closeRes` is designed to run as an independent function - it should consume
+	// errors internally
+
+	closeLogger = func() error { return nil }
+	assert.NotPanics(t, func() { closeRes() })
+
+	closeLogger = func() error { return fmt.Errorf("(%s/main): test error", pkgName) }
+	assert.NotPanics(t, func() { closeRes() })
 }

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -84,6 +84,10 @@ var zapLogger = zap.New(
 	),
 ).Sugar()
 
+func init() {
+	streamCloser() // might as well just hit 100% coverage	¯\_(ツ)_/¯
+}
+
 /*
 Log modifies the logger to log events at or above zap.DebugLevel, and write logs to
 a file


### PR DESCRIPTION
This PR introduces a new package `src/logger` that acts as a wrapper around [`uber-go/zap`][zap-link]. At the same time, it removes all the boilerplate code that comes with [*go-template*][go-template]!

The package exposes a simple API using which the rest of the app can log events/messages;

```go
func logger.Debug(...interface{})
func logger.Info(...interface{})
func logger.Warn(...interface{})
func logger.Error(...interface{})
````

Each of these functions has its own `fmt.Printf` style variant for convenience;

```go
func logger.Debugf(string, ...interface{})
func logger.Infof(string, ...interface{})
func logger.Warnf(string, ...interface{})
func logger.Errorf(string, ...interface{})
```

Note the lack of a `logger.Fatal` method - this is **intended**, a logger should be responsible for writing logs, nothing more!

A logger attempting to kill the program is just... weird

## Details

#### Starting the Logger

The package `logger` internally creates an instance of [`zap.SugaredLogger`][sugared-logger] (no external call required for this). Packages can simply import the package `logger` and use any of its public functions as needed!

By default, the logger is configured to ignore events below the \`warn\` level, and writes them to `stderr` - i.e. only warnings and errors would be logged!

The logger can be "enabled" - i.e. made to log **all events**, i.e. events at `Debug` and `Info` levels in addition to `Warn` and `Error` levels!

```go
func Log(writeToFile bool) error
```

With `writeToFile` enabled, the logs would be written to a text file - "`logs.txt`" - in addition to stderr!

#### Closing the Logger

At this point, under normal circumstances, a running instance of the program can be killed directly without any issues! However, when the logger is writing logs to a file (in addition to stderr) - closing the logger directly could cause loss of information! To safely close the logger, use `logger.Stop`

```go
func Stop() error
```

[zap-link]: https://github.com/uber-go/zap
[go-template]: https://github.com/notsatan/go-template
[sugared-logger]: https://pkg.go.dev/go.uber.org/zap#Logger.Sugar

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [x] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [x] I've read the [`Code of Conduct`](../blob/master/CODE_OF_CONDUCT.md) and this pull request adheres to it.
- [x] I've read the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) guide.
- [x] I've ran the complete test-suite using `make test-suite`, and it passed with no errors.
- [x] I've written new tests for all changes introduced in this pull request (where applicable).
- [x] I've documented any new methods/structures/packages added.

<!--
    Leave this section as-is, no changes are to be made below this point!
-->
## Review Process

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches.
3. For shorter, "quick" PRs, use your best judgment on the previous point.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.
6. In case of a potential bug in PR, be sure to add steps to reproduce the issue (where applicable)
