### PR TITLE
Feature: Define package `logger` as a wrapper over `uber-go/zap`

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,7 +3,7 @@ name: Linter
 on:
   push:
     branches:
-      - '*'
+      - '**'
       - '!draft**'
   pull_request:
     types: [ opened, reopened ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - '**'
       - '!draft**'
   pull_request:
     types: [ opened, reopened ]

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,16 @@ module github.com/notsatan/crcgen
 
 go 1.17
 
-require go.uber.org/zap v1.20.0
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.0
+	go.uber.org/zap v1.20.0
+)
 
 require (
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/notsatan/crcgen
 
 go 1.17
+
+require go.uber.org/zap v1.20.0
+
+require (
+	github.com/pkg/errors v0.9.1 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.7.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -10,7 +11,6 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
@@ -19,6 +19,7 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
@@ -52,6 +53,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,10 @@ github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -52,6 +54,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -1,9 +1,62 @@
 package main
 
 import (
-	"fmt"
+	"os"
+
+	"github.com/notsatan/crcgen/src/logger"
+)
+
+const (
+	pkgName   = "main"
+	debugMode = "debug_mode"
+)
+
+var (
+	// initLogger maps calls to logger.Log
+	initLogger = logger.Log
+
+	// exit maps calls to os.Exit
+	exit = os.Exit
+
+	// closeLogger maps calls to logger.Stop
+	closeLogger = logger.Stop
 )
 
 func main() {
-	fmt.Println("Running")
+	defer closeRes()
+
+	if _, ok := os.LookupEnv(debugMode); ok {
+		// In `debug` mode, switch logger to write all logs to `stderr`
+		err := initLogger(false)
+		crashOnErr(err, "Failed to start logger")
+
+		logger.Debugf("(%s/main): Detected `debug` mode", pkgName)
+	}
+}
+
+/*
+crashOnErr is a simple helper function to ensure a "graceful" crash if the main thread
+encounters an error.
+
+The function prints an error message to the user, closes resources and force closes the
+application
+*/
+func crashOnErr(err error, cause string) {
+	if err == nil {
+		return
+	}
+
+	logger.Errorf("(%s/main): %s: %s", pkgName, cause, err)
+	closeRes() // close resources
+
+	exit(-10)
+}
+
+/*
+closeRes attempts to close resources, designed to be run before the app closes
+*/
+func closeRes() {
+	if err := closeLogger(); err != nil {
+		logger.Errorf("(%s/main): Failed to close logger: %s", pkgName, err)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/notsatan/crcgen/src/logger"
 )
 
 const (
@@ -18,9 +24,19 @@ func resetEnv() {
 	_ = os.Unsetenv(envBuild)
 }
 
+func reset() {
+	exit = os.Exit
+	initLogger = logger.Log
+	closeLogger = logger.Stop
+}
+
 func TestMain(m *testing.M) {
 	// Run all tests, unset env variables, and exit
 	resetEnv()
+
+	// TODO: Figure out a better way than running tests in debug mode
+	_ = os.Setenv(debugMode, "debug")
+
 	val := m.Run()
 	resetEnv()
 	os.Exit(val)
@@ -28,4 +44,30 @@ func TestMain(m *testing.M) {
 
 func TestMainMethod(_ *testing.T) {
 	main()
+}
+
+func TestCrashOnErr(t *testing.T) {
+	defer reset()
+
+	calls := 0
+	exit = func(int) { calls++ } // increment `calls` when `exit` is run by `CrashOnErr`
+
+	crashOnErr(nil, "") // `exit` should not be called without an error
+	assert.Equal(t, calls, 0)
+
+	crashOnErr(errors.New("test"), "test message")
+	assert.Equal(t, calls, 1)
+}
+
+func TestCloseRes(t *testing.T) {
+	defer reset()
+
+	// `closeRes` is designed to run as an independent function - it should consume
+	// errors internally
+
+	closeLogger = func() error { return nil }
+	assert.NotPanics(t, func() { closeRes() })
+
+	closeLogger = func() error { return fmt.Errorf("(%s/main): test error", pkgName) }
+	assert.NotPanics(t, func() { closeRes() })
 }

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -122,3 +122,61 @@ func Stop() error {
 
 	return errors.Wrapf(err, "(%s/Stop)", pkgName)
 }
+
+/*********************************** Boilerplate **************************************/
+
+/*
+Debug writes log messages to the `debug` level
+*/
+func Debug(args ...interface{}) {
+	zapLogger.Debug(args...)
+}
+
+/*
+Debugf uses `fmt.Sprintf` style formatting to log messages at the `debug` level
+*/
+func Debugf(message string, args ...interface{}) {
+	zapLogger.Debugf(message, args...)
+}
+
+/*
+Info writes log messages at the `info` level
+*/
+func Info(args ...interface{}) {
+	zapLogger.Info(args...)
+}
+
+/*
+Infof uses `fmt.Sprintf` style formatting to log messages at the `info` level
+*/
+func Infof(template string, args ...interface{}) {
+	zapLogger.Infof(template, args...)
+}
+
+/*
+Warn writes log messages at the `warn` level
+*/
+func Warn(args ...interface{}) {
+	zapLogger.Warn(args...)
+}
+
+/*
+Warnf uses `fmt.Sprintf` style formatting to log messages at the `warn` level
+*/
+func Warnf(msg string, args ...interface{}) {
+	zapLogger.Warnf(msg, args...)
+}
+
+/*
+Error writes log messages at the `error` level
+*/
+func Error(args ...interface{}) {
+	zapLogger.Error(args...)
+}
+
+/*
+Errorf uses `fmt.Sprintf` style formatting to log messages at the `error` level
+*/
+func Errorf(template string, args ...interface{}) {
+	zapLogger.Errorf(template, args...)
+}

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -1,0 +1,61 @@
+/*
+Package logger exposes a simple logging interface for the application
+*/
+package logger
+
+import (
+	"os"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	// logWriter is responsible for writing logs to one or more output streams
+	logWriter = zapcore.WriteSyncer(os.Stderr) // no logs written by default
+
+	// logLevel indicates the minimum log level required for an event to be logged
+	logLevel = zap.NewAtomicLevelAt(zap.InfoLevel)
+)
+
+/*
+config simply defines the logger configuration
+*/
+var config = zapcore.EncoderConfig{
+	// Empty value removes the field from logs
+	TimeKey:       "set",
+	NameKey:       "set",
+	LevelKey:      "set",
+	MessageKey:    "set",
+	CallerKey:     "set",
+	StacktraceKey: "set",
+
+	// Defaults to a new-line, good enough
+	LineEnding: zapcore.DefaultLineEnding,
+
+	// Modify log level tag to be `[INFO]` instead of `INFO`
+	EncodeLevel: func(level zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+		enc.AppendString("[" + level.CapitalString() + "]")
+	},
+
+	// Custom date-time format for log messages
+	EncodeTime: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+		enc.AppendString(t.Format("02:01:06::3:04:05 PM")) // dd/mm/yy::<time>
+	},
+}
+
+// zapLogger is the central logger used by the package to write logs, logLevel decides
+// the minimum log level required for an event to be logged, while logWriter decides
+// the streams where the logs are written (file, stderr, etc.)
+var zapLogger = zap.New(
+	zapcore.NewCore(
+		zapcore.NewConsoleEncoder(config),
+		logWriter,
+		logLevel,
+	),
+).Sugar()
+
+func init() {
+	zapLogger.Info("Logger is running")
+}

--- a/src/logger/logger_test.go
+++ b/src/logger/logger_test.go
@@ -112,6 +112,27 @@ func TestStop_SyncError(t *testing.T) {
 	assert.Error(t, Stop(), "logger did not propagate error")
 }
 
-func TestRunLogger(t *testing.T) {
-	assert.NotPanics(t, func() { zapLogger.Warn("Running logger") })
+func TestPublicMethods(t *testing.T) {
+	// TODO: Write this test better
+	normal := []func(...interface{}){
+		Debug,
+		Info,
+		Warn,
+		Error,
+	}
+
+	formatted := []func(string, ...interface{}){
+		Debugf,
+		Infof,
+		Warnf,
+		Errorf,
+	}
+
+	for _, function := range normal {
+		function("test")
+	}
+
+	for _, function := range formatted {
+		function("test")
+	}
 }

--- a/src/logger/logger_test.go
+++ b/src/logger/logger_test.go
@@ -1,7 +1,117 @@
 package logger
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"testing"
 
-func TestLogger(t *testing.T) {
-	zapLogger.Debug("Logger is running")
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// openFixtureCalled indicates if openFixture was called
+var openFixtureCalled = false
+
+// openFixture is a test fixture to overwrite openLogFile lambda - returns empty
+// response, modifies value of openFixtureCalled to indicate the function was called
+var openFixture = func(...string) (zapcore.WriteSyncer, func(), error) {
+	openFixtureCalled = true
+	return nil, func() {}, nil
+}
+
+// reset rolls back values of variables/lambdas to their defaults
+func reset() {
+	openLogFile = zap.Open
+	sync = (*zap.SugaredLogger).Sync
+
+	openFixtureCalled = false
+	streamCloser = func() {}
+	logLevel.SetLevel(zap.WarnLevel)
+}
+
+func TestLog_LogToStderr(t *testing.T) {
+	// Ensures a call to `Log` modifies the log level without opening the log file
+
+	defer reset()
+
+	openLogFile = openFixture // replace actual function with the fixture
+	assert.NoError(t, Log(false))
+
+	assert.Equal(t, zap.DebugLevel, logLevel.Level()) // log level should be modified
+	assert.False(
+		t, openFixtureCalled, "unexpected attempt to open the log file",
+	)
+}
+
+func TestLog_LogToFile(t *testing.T) {
+	// Ensure logging to a file opens the log file, and modifies the log level
+
+	defer reset()
+
+	openLogFile = openFixture
+	assert.NoError(t, Log(true)) // logs written to file
+
+	assert.Equal(t, zap.DebugLevel, logLevel.Level())
+	assert.True(
+		t, openFixtureCalled, "no attempt made to open the log file",
+	)
+}
+
+func TestLog_OpenFileError(t *testing.T) {
+	// Tests the scenario when opening a log file results in an error - log level should
+	// be modified, and the function should return an error
+
+	defer reset()
+
+	// Modify `openLogFile` lambda to return an error
+	openLogFile = func(...string) (zapcore.WriteSyncer, func(), error) {
+		return nil, func() {}, fmt.Errorf(
+			"(%s/TestLog_OpenFileError): test error", pkgName,
+		)
+	}
+
+	assert.Error(t, Log(true), "`logger.Log` failed to return error during failure")
+	assert.Equal(t, zap.DebugLevel, logLevel.Level())
+}
+
+func TestStop_NoError(t *testing.T) {
+	// No error should occur when `sync` does not fail
+
+	defer reset()
+
+	sync = func(*zap.SugaredLogger) error { return nil }
+	assert.NoError(t, Stop(), "unexpected error when stopping the logger")
+}
+
+func TestStop_LinuxError(t *testing.T) {
+	// Failure to sync the logger is expected on linux - error should be suppressed
+
+	defer reset()
+
+	sync = func(*zap.SugaredLogger) error { return errors.New("/dev/stderr") }
+
+	// Error would be suppressed only for tests running on Linux
+	if runtime.GOOS == "linux" {
+		assert.NoError(t, Stop(), "failed to suppress logger sync error on linux")
+	} else {
+		assert.Error(t, Stop(), "logger didn't return error after failing to sync")
+	}
+}
+
+func TestStop_SyncError(t *testing.T) {
+	// If `Stop` fails, an error should be returned
+
+	defer reset()
+
+	sync = func(*zap.SugaredLogger) error {
+		return fmt.Errorf("(%s/TestStop_SyncError): test error", pkgName)
+	}
+
+	assert.Error(t, Stop(), "logger did not propagate error")
+}
+
+func TestRunLogger(t *testing.T) {
+	assert.NotPanics(t, func() { zapLogger.Warn("Running logger") })
 }

--- a/src/logger/logger_test.go
+++ b/src/logger/logger_test.go
@@ -1,0 +1,7 @@
+package logger
+
+import "testing"
+
+func TestLogger(t *testing.T) {
+	zapLogger.Debug("Logger is running")
+}


### PR DESCRIPTION
This PR introduces a new package `src/logger` that acts as a wrapper around [`uber-go/zap`][zap-link]. At the same time, it removes all the boilerplate code that comes with [*go-template*][go-template]!

The package exposes a simple API using which the rest of the app can log events/messages;

```go
func logger.Debug(...interface{})
func logger.Info(...interface{})
func logger.Warn(...interface{})
func logger.Error(...interface{})
````

Each of these functions has its own `fmt.Printf` style variant for convenience;

```go
func logger.Debugf(string, ...interface{})
func logger.Infof(string, ...interface{})
func logger.Warnf(string, ...interface{})
func logger.Errorf(string, ...interface{})
```

Note the lack of a `logger.Fatal` method - this is **intended**, a logger should be responsible for writing logs, nothing more!

A logger attempting to kill the program is just... weird

## Details

#### Starting the Logger

The package `logger` internally creates an instance of [`zap.SugaredLogger`][sugared-logger] (no external call required for this). Packages can simply import the package `logger` and use any of its public functions as needed!

By default, the logger is configured to ignore events below the \`warn\` level, and writes them to `stderr` - i.e. only warnings and errors would be logged!

The logger can be "enabled" - i.e. made to log **all events**, i.e. events at `Debug` and `Info` levels in addition to `Warn` and `Error` levels!

```go
func Log(writeToFile bool) error
```

With `writeToFile` enabled, the logs would be written to a text file - "`logs.txt`" - in addition to stderr!

#### Closing the Logger

At this point, under normal circumstances, a running instance of the program can be killed directly without any issues! However, when the logger is writing logs to a file (in addition to stderr) - closing the logger directly could cause loss of information! To safely close the logger, use `logger.Stop`

```go
func Stop() error
```

[zap-link]: https://github.com/uber-go/zap
[go-template]: https://github.com/notsatan/go-template
[sugared-logger]: https://pkg.go.dev/go.uber.org/zap#Logger.Sugar

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [x] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [x] I've read the [`Code of Conduct`](../blob/master/CODE_OF_CONDUCT.md) and this pull request adheres to it.
- [x] I've read the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) guide.
- [x] I've ran the complete test-suite using `make test-suite`, and it passed with no errors.
- [x] I've written new tests for all changes introduced in this pull request (where applicable).
- [x] I've documented any new methods/structures/packages added.

<!--
    Leave this section as-is, no changes are to be made below this point!
-->
## Review Process

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches.
3. For shorter, "quick" PRs, use your best judgment on the previous point.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.
6. In case of a potential bug in PR, be sure to add steps to reproduce the issue (where applicable)